### PR TITLE
Backend update appointment

### DIFF
--- a/Fitzys_Fades/server/models/Appointment.js
+++ b/Fitzys_Fades/server/models/Appointment.js
@@ -11,7 +11,7 @@ const appointmentSchema = new Schema({
     required: true, // selected from the calendar
   },
   time: {
-    type: Date,
+    type: String,
     required: true, // selected from the time slot thing
   },
   service: {

--- a/Fitzys_Fades/server/models/Appointment.js
+++ b/Fitzys_Fades/server/models/Appointment.js
@@ -7,7 +7,7 @@ const appointmentSchema = new Schema({
     required: true,
   },
   date: {
-    type: Date,
+    type: String,
     required: true, // selected from the calendar
   },
   time: {

--- a/Fitzys_Fades/server/schemas/resolvers.js
+++ b/Fitzys_Fades/server/schemas/resolvers.js
@@ -47,33 +47,27 @@ const resolvers = {
     },
 
     //Update the signed in user's profile information
-    updateUser: async (_, { id, user_name, email, phone, password }, context) => {
+    updateUser: async (_, args, context) => {
       if (!context.user) {
-        throw new Error(
-          "You need to be logged in to update this profile!"
-        );
+        throw new Error("You need to be logged in to update this profile!"); //have to uncomment this to work
       }
+      const { id, user_name, email, phone, password} = args
       const user = await User.findById(id);
       if (!user) {
         throw new Error("User not found");
       }
       if (user.toString() !== context.user._id.toString()) {
-        throw new Error(
-          "You don't have access to update this profile"
-        );
+        throw new Error("You don't have access to update this profile"); //have to uncomment this to work
       }
-      user.user_name = user_name;
-      user.email = email;
-      user.phone = phone;
-      user.password = password;
-
+      const updatedArgs = { id, user_name, email, phone, password}
+      user.set(updatedArgs)
       await user.save();
-
       return user;
     },
+
     createAppointment: async (
       parent,
-      { barber_name, date, time, service },
+{ barber_name, date, time, service },
       context
     ) => {
       const appointment = await Appointment.create({
@@ -100,41 +94,24 @@ const resolvers = {
     },
 
     //update the signed in user's appointment detail
-    updateAppointment: async (_, { id, barber_name, date, time, service }, context) => {
+    updateAppointment: async (_, args, context) => {
       if (!context.user) {
-        throw new Error(
-          "You need to be logged in to update this appointment!"
-        );
+        throw new Error("You need to be logged in to update this appointment!"); // have to uncomment this to work
       }
-      const appointment = await Appointment.findById(id);
+      const { barber_name, date, time, service } = args;
+      const appointment = await Appointment.findById(args.id);
       if (!appointment) {
         throw new Error("Appointment not found");
       }
       if (appointment.user.toString() !== context.user._id.toString()) {
-        throw new Error(
-          "You don't have access to update this appointment"
-        );
+        throw new Error("You don't have access to update this appointment"); //have to uncomment this to work
       }
-      appointment.barber_name = barber_name;
-      appointment.date = date;
-      appointment.time = time;
-      appointment.service = service;
-
+      const updatedArgs = { barber_name, date, time, service };
+      appointment.set(updatedArgs);
       await appointment.save();
-
       return appointment;
     },
   },
 };
 
 module.exports = resolvers;
-
-// Create User - DONE
-// Get all User - DONE
-// Get one User - DONE
-// Update User - DONE?
-// Create Appointment - DONE
-// Get all Appointment - DONE
-// Get one Appointment - DONE
-// Update Appointment - DONE?
-// Delete Appointment - DONE?

--- a/Fitzys_Fades/server/schemas/resolvers.js
+++ b/Fitzys_Fades/server/schemas/resolvers.js
@@ -49,7 +49,7 @@ const resolvers = {
     //Update the signed in user's profile information
     updateUser: async (_, { id, user_name, email, phone, password }, context) => {
       if (!context.user) {
-        throw new AuthenticationError(
+        throw new Error(
           "You need to be logged in to update this profile!"
         );
       }
@@ -58,7 +58,7 @@ const resolvers = {
         throw new Error("User not found");
       }
       if (user.toString() !== context.user._id.toString()) {
-        throw new AuthenticationError(
+        throw new Error(
           "You don't have access to update this profile"
         );
       }
@@ -102,7 +102,7 @@ const resolvers = {
     //update the signed in user's appointment detail
     updateAppointment: async (_, { id, barber_name, date, time, service }, context) => {
       if (!context.user) {
-        throw new AuthenticationError(
+        throw new Error(
           "You need to be logged in to update this appointment!"
         );
       }
@@ -111,7 +111,7 @@ const resolvers = {
         throw new Error("Appointment not found");
       }
       if (appointment.user.toString() !== context.user._id.toString()) {
-        throw new AuthenticationError(
+        throw new Error(
           "You don't have access to update this appointment"
         );
       }

--- a/Fitzys_Fades/server/schemas/typeDefs.js
+++ b/Fitzys_Fades/server/schemas/typeDefs.js
@@ -48,15 +48,13 @@ const typeDefs = `
     me: User
   }
 
-
-
   type Mutation {
     createUser(userInput: UserInput!): Auth
     login(email: String!, password: String!): Auth
     createAppointment(barber_name: BarberEnum!, date: String!, time: String!, service: ServiceEnum!): Appointment
     deleteAppointment(id: ID!): User
-    updateAppointment(barber_name: BarberEnum!, date: String!, time: String!, service: ServiceEnum!): Appointment
-    updateUser(user_name: String!, email: String!, phone: String!, password: String!): User
+    updateAppointment(id:ID!, barber_name: BarberEnum!, date: String!, time: String!, service: ServiceEnum!): Appointment
+    updateUser(id:ID!, user_name: String!, email: String!, phone: String!, password: String!): User
   }
 `;
 

--- a/Fitzys_Fades/server/schemas/typeDefs.js
+++ b/Fitzys_Fades/server/schemas/typeDefs.js
@@ -55,6 +55,8 @@ const typeDefs = `
     login(email: String!, password: String!): Auth
     createAppointment(barber_name: BarberEnum!, date: String!, time: String!, service: ServiceEnum!): Appointment
     deleteAppointment(id: ID!): User
+    updateAppointment(barber_name: BarberEnum!, date: String!, time: String!, service: ServiceEnum!): Appointment
+    updateUser(user_name: String!, email: String!, phone: String!, password: String!): User
   }
 `;
 

--- a/Fitzys_Fades/server/seeds/appointmentSeeds.json
+++ b/Fitzys_Fades/server/seeds/appointmentSeeds.json
@@ -1,0 +1,20 @@
+[
+  {
+    "barber_name": "JOHN_DOE",
+    "date": "2024-10-15",
+    "time": "14:30:00",
+    "service": "FADE"
+  },
+  {
+    "barber_name": "JANE_DAWN",
+    "date": "2024-10-20",
+    "time": "10:00:00",
+    "service": "CUT"
+  },
+  {
+    "barber_name": "WILLIAM_WILLIAMS",
+    "date": "2024-10-25",
+    "time": "16:00:00",
+    "service": "SHAVE"
+  }
+]

--- a/Fitzys_Fades/server/seeds/fitzysFadesdb.js
+++ b/Fitzys_Fades/server/seeds/fitzysFadesdb.js
@@ -1,0 +1,17 @@
+const models = require("../models");
+const db = require("../config/connection");
+
+module.exports = async (modelName, collectionName) => {
+  try {
+    let modelExists = await models[modelName].db.db
+      .listCollections({
+        name: collectionName,
+      })
+      .toArray();
+    if (modelExists.length) {
+      await db.dropCollection(collectionName);
+    }
+  } catch (err) {
+    throw err;
+  }
+};

--- a/Fitzys_Fades/server/seeds/seed.js
+++ b/Fitzys_Fades/server/seeds/seed.js
@@ -1,0 +1,32 @@
+const db = require('../config/connection')
+const {User, Appointment} = require('../models')
+const userSeeds = require('./userSeeds.json')
+const appointmentSeeds = require('./appointmentSeeds.json')
+const fitzysFadesdb = require('./fitzysFadesdb')
+
+db.once('open', async () => {
+    try {
+      await fitzysFadesdb('Appointment', 'appointments');
+      await fitzysFadesdb('User', 'users');
+  
+      await User.create(userSeeds);
+      
+      for (let i = 0; i < appointmentSeeds.length; i++) {
+        const randomUserIndex = Math.floor(Math.random() * userSeeds.length);
+        const randomUser = userSeeds[randomUserIndex];
+  
+        const { _id } = await Appointment.create(appointmentSeeds[i]);
+        
+        const user = await User.findOneAndUpdate(
+          { user_name: randomUser.user_name },
+          { $addToSet: { appointments: _id } }
+        );
+      }
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
+    }
+  
+    console.log('All appointments have been randomly assigned to users.');
+    process.exit(0);
+  });

--- a/Fitzys_Fades/server/seeds/userSeeds.json
+++ b/Fitzys_Fades/server/seeds/userSeeds.json
@@ -1,0 +1,23 @@
+[
+  {
+    "user_name": "John Wick",
+    "email": "youkilledmydog@gmail.com",
+    "phone": "647-555-5555",
+    "password": "nobodykillsmydog",
+    "appointments": []
+  },
+  {
+  "user_name": "Norman Bates",
+  "email": "stabbystabby@gmail.com",
+  "phone": "647-555-1111",
+  "password": "w0nthurtafly",
+  "appointments": []
+  },
+  {
+    "user_name": "Norma Bate's Mom",
+    "email": "imnotdead@aol.com",
+    "phone": "647-555-1111",
+    "password": "mys0nwonthurtaFly",
+    "appointments": []
+  }
+]


### PR DESCRIPTION
Added updateUser and updateAppointment to the mutations in resolver.js
Added updateUser and updateAppointment to typedefs.js

Created appointmentSeeds.json, userSeeds.json, Seed.js, and fitzysFadesdb.js in seeds folder for testing.
Works in studio 3T, user and appointment now each have 3 entries and appointments are randomly assigned to users.

changed data type of time in appointment.js from date to string, then seeding works

errors were due to:
1) me not knowing how to use the sandbox
2) code block requiring authentication that user is logged in and that they are not updating some other user's appointments. don't know how to manually set it up to simulate a logged in scenario with sandbox, but if those code are commented out updateUser and updateAppointment works. I've added comments to those parts if you want to test the functionality yourself

I also don't know if this will affect how frontend works in the future. the current code requires all fields to be filled in no matter if it is changed on not. my assumption is that when the user clicks on their profile tab the profile will grab everything but only display user_name, phone, email, and password. the user can change what they want, and when they click edit profile, it will basically "overwrite" their whole profile with their changes.

Don't know if that made sense.

If we want to allow the user to only edit certain parts of their profile. I will have to create multiple mutations, each specifying which field the user is changing. I will also have to do that with editing the appointments too.

What I'm saying is I need help. A lot of it. What I'm hoping to do is seeing how it works with the frontend and bugfix everything then.